### PR TITLE
Update `die_library`

### DIFF
--- a/libdie++/cmake/FindDieLibrary.cmake
+++ b/libdie++/cmake/FindDieLibrary.cmake
@@ -29,7 +29,9 @@ find_package(Qt6 REQUIRED COMPONENTS Core Concurrent Qml)
 FetchContent_Declare(
   DieLibrary
   GIT_REPOSITORY "https://github.com/horsicq/die_library"
-  GIT_TAG 61c7962c86edf9bce44de3f1da70b9c8978d0b35
+  GIT_TAG 6a0c6aa55af518d6e841436130beb05eb5fc769b
+  # GIT_REPOSITORY "https://github.com/calladoum-elastic/die_library"
+  # GIT_TAG e6f91085fed31b69907ab03f95d6bf8dce7752ac
 )
 
 set(DIE_BUILD_AS_STATIC ON CACHE INTERNAL "")


### PR DESCRIPTION
# Description

Update to latest dielib commit that fixes the thread non-safe issue, causing tests to fail.