### PR TITLE
[Build] Fix `die++` link libraries 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,32 @@ This module provides Rust bindings for the [Detect-It-Easy](https://github.com/h
 - Safe and idiomatic Rust interfaces for interacting with the library.
 - Comprehensive error handling and type safety.
 
-## Install
+### Build
+
+> [!IMPORTANT]
+> [**Qt6**](https://qt.io) libraries must be installed for Detect-it-Easy to work.
+> On Linux and macOS, `die-rust` can be built using the Qt6 provided by the typical package management systems (`apt`, `dnf`, `brew`, etc.).
+> If you do not wish to install those packages system-wide, if you are running Windows, or if you wish/need to use a specific version of Qt6, it is possible to build `die-rust` by installing those libraries in a specific folder, using [`aqtinstall`](https://github.com/miurahr/aqtinstall) - (see below). Then build `die-rust` by passing the paths to the Qt6 libraries with the `QT6_LIB_PATH` environment.
+
+### As a dependency
+
+Use `cargo` to add `die-rust` as a dependency to your project:
+
+```console
+cargo add --git https://github.com/elastic/die-rust.git
+```
+
+### On the terminal
 
 The installation can be done using `cargo`.
 
 ```console
-cargo build --git https://github.com/elastic/die-rust.git
+git clone https://github.com/elastic/die-rust.git
+cd die-rust
+cargo build
 ```
 
-The build requires Qt6 libraries. On Linux/macOS they can usually be obtained from the system's package manager.
-To use a specific Qt6 version, it is possible to use `aqtinstall` as follow
+The build requires Qt6 libraries. On Linux/macOS they can usually be obtained from the system's package manager. To use a specific Qt6 version, it is possible to use `aqtinstall` as follow
 
 ### Linux
 
@@ -51,13 +67,8 @@ python -m aqt install-qt -O ./libdie++/build/ windows desktop $env:QT_BUILD_VERS
 $env:QT6_LIB_PATH="./libdie++/build/6.2.2/msvc2019_64/lib"
 ```
 
-### Build
 
-Then build `die-rust` by passing the paths to the Qt6 libraries with the `QT6_LIB_PATH` environment.
 
-```console
-cargo build
-```
 
 
 ## Examples

--- a/libdie++/CMakeLists.txt
+++ b/libdie++/CMakeLists.txt
@@ -57,7 +57,7 @@ target_compile_definitions(die++
         DIELIB_VERSION="${DIELIB_VERSION}"
 )
 
-target_link_libraries(die++ PRIVATE $<TARGET_FILE:die> $<TARGET_PROPERTY:die,LINK_LIBRARIES>)
+target_link_libraries(die++ PRIVATE $<TARGET_FILE:die>)
 target_link_libraries(die++ PRIVATE Qt6::Core)
 target_link_libraries(die++ PRIVATE Qt6::Qml)
 target_link_libraries(die++ PRIVATE Qt6::Concurrent)

--- a/libdie++/cmake/FindDieLibrary.cmake
+++ b/libdie++/cmake/FindDieLibrary.cmake
@@ -29,9 +29,7 @@ find_package(Qt6 REQUIRED COMPONENTS Core Concurrent Qml)
 FetchContent_Declare(
   DieLibrary
   GIT_REPOSITORY "https://github.com/horsicq/die_library"
-  GIT_TAG 6a0c6aa55af518d6e841436130beb05eb5fc769b
-  # GIT_REPOSITORY "https://github.com/calladoum-elastic/die_library"
-  # GIT_TAG e6f91085fed31b69907ab03f95d6bf8dce7752ac
+  GIT_TAG 5191b2d9c452ee78425bb0e142448b5d442b9f6b
 )
 
 set(DIE_BUILD_AS_STATIC ON CACHE INTERNAL "")


### PR DESCRIPTION
# Description

CMake target `die++` was collecting all linked libraries specified by `die`, including those that were not found. As a consequence if the system building `die` didn't have the Qt5 libraries, the build would fail even though those libs are not needed with the following error

```text
$ cargo build -vv
[...]
  --- stderr
  /home/chris/.cargo/git/checkouts/die-rust-16d54ce51808913d/0e11039/libdie++/build/_deps/dielibrary-src/dep/XCapstone/x86
  /home/chris/.cargo/git/checkouts/die-rust-16d54ce51808913d/0e11039/libdie++/build/_deps/dielibrary-src/src/lib
  CMake Error at CMakeLists.txt:60 (target_link_libraries):
    Target "die++" links to:

      Qt5::Core

    but the target was not found.  Possible reasons include:

      * There is a typo in the target name.
      * A find_package call is missing for an IMPORTED target.
      * An ALIAS target is missing.



  CMake Generate step failed.  Build files cannot be regenerated correctly.
  thread 'main' panicked at /home/chris/.cargo/git/checkouts/die-rust-16d54ce51808913d/0e11039/build.rs:21:9:
  assertion failed: std::process::Command::new("cmake").current_dir(BASE_DIR).args(["-S",
                                      "."]).args(["-B",
                                  "build"]).spawn().unwrap().wait().expect("failed to configure cmake").success()
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

This PR fixes this behavior by only requiring to link `die++` with the libraries required.

The PR also documents better how to install the `die-rust` library in the README.