### PR TITLE
Update versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,22 +44,22 @@ jobs:
       env:
         QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
       run: |
-        cargo build -vv --tests --examples
-        cargo test -vv
+        cargo build -vv --tests --examples --release
+        cargo test -vv --release
 
     - name: Build (Linux)
       env:
         QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
-        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:${QT6_LIB_PATH}"
+        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
       run: |
-        cargo build -vv --tests --examples
-        cargo test -vv
+        cargo build -vv --tests --examples --release
+        cargo test -vv --release
 
     - name: Build (macOS)
       env:
         QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
-        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:${QT6_LIB_PATH}"
+        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
       run: |
-        cargo build -vv --tests --examples
-        cargo test -vv
+        cargo build -vv --tests --examples --release
+        cargo test -vv --release
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         variants:
-          -  {os: ubuntu-22.04, config: release, compiler: gcc_64, aqt_os: linux, aqt_compiler: gcc_64}
+          # -  {os: ubuntu-22.04, config: release, compiler: gcc_64, aqt_os: linux, aqt_compiler: gcc_64}
           -  {os: ubuntu-24.04, config: release, compiler: gcc_64, aqt_os: linux, aqt_compiler: gcc_64}
           # -  {os: ubuntu-24.04-arm, config: release, compiler: linux_gcc_arm64, aqt_os: linux_arm64, aqt_compiler: linux_gcc_arm64}
-          -  {os: windows-2022, config: release, compiler: msvc2022_64, aqt_os: windows, aqt_compiler: win64_msvc2022_64}
+          # -  {os: windows-2022, config: release, compiler: msvc2022_64, aqt_os: windows, aqt_compiler: win64_msvc2022_64}
           -  {os: windows-2025, config: release, compiler: msvc2022_64, aqt_os: windows, aqt_compiler: win64_msvc2022_64}
           -  {os: macos-14, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
           # -  {os: macos-15, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,9 @@ jobs:
       run: |
         $env:QT6_LIB_PATH="./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
         $env:DIE_DB_PATH="./libdie++/install/die/db/db"
-        cargo build -vv --tests --examples
+        cargo build -vv --tests --examples --release
         cp ./libdie++/install/die/*.dll .
-        cargo test -vv
+        cargo test -vv --release
         cargo run --example scan_file -- -vv C:\Windows\System32\winver.exe
 
     - name: Build (Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,12 @@ jobs:
       if: startsWith(matrix.variants.os, 'windows-')
       run: |
         $env:QT6_LIB_PATH="./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
-        $env:DIE_DB_PATH="./db/db"
-        cargo build -vv --tests --examples --release
-        cargo test -vv --release
+        $env:DIE_DB_PATH="./libdie++/install/db"
+        cargo build -vv --tests --examples
+        cp ./libdie++/install/die/*.dll .
+        cargo test -vv
         cd libdie++\install\die
+        $env:DIE_DB_PATH=".\db"
         cargo run --example scan_file -- -vv /bin/ls --database-path $env:DIE_DB_PATH
 
     - name: Build (Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         cargo build -vv --tests --examples --release
         cp ./libdie++/install/die/*.dll .
         cargo test -vv --release
-        cargo run --example scan_file -- -vv C:\Windows\System32\winver.exe
+        cargo run --release --example scan_file -- -vv C:\Windows\System32\winver.exe
 
     - name: Build (Linux)
       if: startsWith(matrix.variants.os, 'ubuntu-')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           -  {os: windows-2022, config: release, compiler: msvc2022_64, aqt_os: windows, aqt_compiler: win64_msvc2022_64}
           -  {os: windows-2025, config: release, compiler: msvc2022_64, aqt_os: windows, aqt_compiler: win64_msvc2022_64}
           -  {os: macos-14, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
-          -  {os: macos-15, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
+          # -  {os: macos-15, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
     runs-on: ${{ matrix.variants.os }}
     steps:
     - uses: actions/checkout@v5
@@ -54,8 +54,8 @@ jobs:
         export QT6_LIB_PATH="`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
         export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
         export DIE_DB_PATH="`pwd`/libdie++/install/die/db/db"
-        cargo build -vv --tests --examples --release
-        cargo test -vv --release
+        cargo build -vv --tests --examples
+        cargo test -vv
         cargo run --example scan_file -- -vv /bin/ls --database-path ${DIE_DB_PATH}
 
     - name: Build (macOS)
@@ -64,7 +64,7 @@ jobs:
         export QT6_LIB_PATH="`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
         export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
         export DIE_DB_PATH="`pwd`/libdie++/install/die/db/db"
-        cargo build -vv --tests --examples --release
-        cargo test -vv --release
+        cargo build -vv --tests --examples
+        cargo test -vv
         cargo run --example scan_file -- -vv /bin/ls --database-path ${DIE_DB_PATH}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,6 @@ jobs:
         cargo build -vv --tests --examples
         cp ./libdie++/install/die/*.dll .
         cargo test -vv
-        cd libdie++\install\die
-        $env:DIE_DB_PATH=".\db"
         cargo run --example scan_file -- -vv /bin/ls --database-path $env:DIE_DB_PATH
 
     - name: Build (Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,10 @@ jobs:
           -  {os: macos-14, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
           -  {os: macos-15, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
     runs-on: ${{ matrix.variants.os }}
+    env:
+      QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: actions/cache@v4
       with:
         path: |
@@ -58,7 +60,6 @@ jobs:
         echo QT6_LIB_PATH=${QT6_LIB_PATH} >> $GITHUB_ENV
 
     - name: Build (Windows)
-      if: startsWith(matrix.variants.os, 'windows-')
       run: |
         python -m pip install aqtinstall --user --upgrade
         python -m aqt install-qt -O libdie++/build ${{ matrix.variants.aqt_os }} desktop ${{ env.QT_BUILD_VERSION }} ${{ matrix.variants.aqt_compiler }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,11 +42,11 @@ jobs:
       if: startsWith(matrix.variants.os, 'windows-')
       run: |
         $env:QT6_LIB_PATH="./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
-        $env:DIE_DB_PATH="./libdie++/install/db"
+        $env:DIE_DB_PATH="./libdie++/install/die/db/db"
         cargo build -vv --tests --examples
         cp ./libdie++/install/die/*.dll .
         cargo test -vv
-        cargo run --example scan_file -- -vv /bin/ls --database-path $env:DIE_DB_PATH
+        cargo run --example scan_file -- -vv C:\Windows\System32\winver.exe
 
     - name: Build (Linux)
       if: startsWith(matrix.variants.os, 'ubuntu-')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         variants:
+          -  {os: ubuntu-22.04, config: release, compiler: gcc_64, aqt_os: linux, aqt_compiler: gcc_64}
           -  {os: ubuntu-24.04, config: release, compiler: gcc_64, aqt_os: linux, aqt_compiler: gcc_64}
           # -  {os: ubuntu-24.04-arm, config: release, compiler: linux_gcc_arm64, aqt_os: linux_arm64, aqt_compiler: linux_gcc_arm64}
-          -  {os: windows-2019, config: release, compiler: msvc2022_64, aqt_os: windows, aqt_compiler: win64_msvc2022_64}
-          -  {os: macos-13, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
+          -  {os: windows-2022, config: release, compiler: msvc2022_64, aqt_os: windows, aqt_compiler: win64_msvc2022_64}
+          -  {os: windows-2025, config: release, compiler: msvc2022_64, aqt_os: windows, aqt_compiler: win64_msvc2022_64}
           -  {os: macos-14, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
           -  {os: macos-15, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
     runs-on: ${{ matrix.variants.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  QT_BUILD_VERSION: 6.2.2
+  QT_BUILD_VERSION: 6.10.0
 
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
         variants:
           -  {os: ubuntu-24.04, config: release, compiler: gcc_64, aqt_os: linux, aqt_compiler: gcc_64}
           # -  {os: ubuntu-24.04-arm, config: release, compiler: linux_gcc_arm64, aqt_os: linux_arm64, aqt_compiler: linux_gcc_arm64}
-          -  {os: windows-2019, config: release, compiler: msvc2019_64, aqt_os: windows, aqt_compiler: win64_msvc2019_64}
+          -  {os: windows-2019, config: release, compiler: msvc2022_64, aqt_os: windows, aqt_compiler: win64_msvc2022_64}
           -  {os: macos-13, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
           -  {os: macos-14, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
           -  {os: macos-15, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,6 @@ jobs:
           -  {os: macos-14, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
           -  {os: macos-15, config: release, compiler: clang_64, aqt_os: mac, aqt_compiler: clang_64}
     runs-on: ${{ matrix.variants.os }}
-    env:
-      QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
     steps:
     - uses: actions/checkout@v5
     - uses: actions/cache@v4
@@ -41,48 +39,30 @@ jobs:
           target/
         key: ${{ matrix.variants.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Build (Linux)
-      if: startsWith(matrix.variants.os, 'ubuntu-')
+    - name: Build
+      env:
+        QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
       run: |
-        python -m pip install aqtinstall --user --upgrade
-        python -m aqt install-qt -O libdie++/build ${{ matrix.variants.aqt_os }} desktop ${{ env.QT_BUILD_VERSION }} ${{ matrix.variants.aqt_compiler }}
-        export QT6_LIB_PATH="`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
-        cargo build -vv --tests --examples
-        echo QT6_LIB_PATH=${QT6_LIB_PATH} >> $GITHUB_ENV
-
-    - name: Build (macOS)
-      if: startsWith(matrix.variants.os, 'macos-')
-      run: |
-        python -m pip install aqtinstall --user --upgrade
-        python -m aqt install-qt -O libdie++/build ${{ matrix.variants.aqt_os }} desktop ${{ env.QT_BUILD_VERSION }} ${{ matrix.variants.aqt_compiler }}
-        export QT6_LIB_PATH="`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
-        cargo build -vv --tests --examples
-        echo QT6_LIB_PATH=${QT6_LIB_PATH} >> $GITHUB_ENV
-
-    - name: Build (Windows)
-      run: |
-        python -m pip install aqtinstall --user --upgrade
-        python -m aqt install-qt -O libdie++/build ${{ matrix.variants.aqt_os }} desktop ${{ env.QT_BUILD_VERSION }} ${{ matrix.variants.aqt_compiler }}
-        $env:QT6_LIB_PATH="./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
         cargo build -vv --tests --examples
 
-    - name: Tests (Linux)
+    - name: Test Setup (Linux)
       if: startsWith(matrix.variants.os, 'ubuntu-')
       run: |
         export QT6_LIB_PATH="`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${QT6_LIB_PATH}
-        cargo test -vv
 
-    - name: Tests (macOS)
+    - name: Test Setup (macOS)
       if: startsWith(matrix.variants.os, 'macos-')
       run: |
         export QT6_LIB_PATH="`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${QT6_LIB_PATH}
-        cargo test -vv
 
-    - name: Tests (Windows)
+    - name: Test Setup (Windows)
       if: startsWith(matrix.variants.os, 'windows-')
       run: |
         $env:QT6_LIB_PATH="./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
         cp -v ./libdie++/install/die/*.dll .
+
+    - name: Test
+      run: |
         cargo test -vv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,30 +39,27 @@ jobs:
           target/
         key: ${{ matrix.variants.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Build
+    - name: Build (Windows)
+      if: startsWith(matrix.variants.os, 'windows-')
       env:
         QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
       run: |
         cargo build -vv --tests --examples
-
-    - name: Test Setup (Linux)
-      if: startsWith(matrix.variants.os, 'ubuntu-')
-      run: |
-        export QT6_LIB_PATH="`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${QT6_LIB_PATH}
-
-    - name: Test Setup (macOS)
-      if: startsWith(matrix.variants.os, 'macos-')
-      run: |
-        export QT6_LIB_PATH="`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${QT6_LIB_PATH}
-
-    - name: Test Setup (Windows)
-      if: startsWith(matrix.variants.os, 'windows-')
-      run: |
-        $env:QT6_LIB_PATH="./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
-        cp -v ./libdie++/install/die/*.dll .
-
-    - name: Test
-      run: |
         cargo test -vv
+
+    - name: Build (Linux)
+      env:
+        QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
+        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:${QT6_LIB_PATH}"
+      run: |
+        cargo build -vv --tests --examples
+        cargo test -vv
+
+    - name: Build (macOS)
+      env:
+        QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
+        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:${QT6_LIB_PATH}"
+      run: |
+        cargo build -vv --tests --examples
+        cargo test -vv
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ env:
   CARGO_TERM_COLOR: always
   QT_BUILD_VERSION: 6.10.0
 
-
 jobs:
   build:
     strategy:
@@ -41,25 +40,31 @@ jobs:
 
     - name: Build (Windows)
       if: startsWith(matrix.variants.os, 'windows-')
-      env:
-        QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
       run: |
+        $env:QT6_LIB_PATH="./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
+        $env:DIE_DB_PATH="./db/db"
         cargo build -vv --tests --examples --release
         cargo test -vv --release
+        cd libdie++\install\die
+        cargo run --example scan_file -- -vv /bin/ls --database-path $env:DIE_DB_PATH
 
     - name: Build (Linux)
-      env:
-        QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
-        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
+      if: startsWith(matrix.variants.os, 'ubuntu-')
       run: |
+        export QT6_LIB_PATH="`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
+        export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/${{ matrix.variants.compiler }}/lib"
+        export DIE_DB_PATH="`pwd`/libdie++/install/die/db/db"
         cargo build -vv --tests --examples --release
         cargo test -vv --release
+        cargo run --example scan_file -- -vv /bin/ls --database-path ${DIE_DB_PATH}
 
     - name: Build (macOS)
-      env:
-        QT6_LIB_PATH: "./libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
-        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
+      if: startsWith(matrix.variants.os, 'macos-')
       run: |
+        export QT6_LIB_PATH="`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
+        export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:`pwd`/libdie++/build/${{ env.QT_BUILD_VERSION }}/macos/lib"
+        export DIE_DB_PATH="`pwd`/libdie++/install/die/db/db"
         cargo build -vv --tests --examples --release
         cargo test -vv --release
+        cargo run --example scan_file -- -vv /bin/ls --database-path ${DIE_DB_PATH}
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ libdie++/build
 libdie++/install
 .vscode
 aqtinstall.log
+*.dll

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,18 +114,18 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "die"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "die"
-version = "0.1.0"
-edition = "2021"
+version = "0.2.0"
+edition = "2024"
 authors = ["Christophe Alladoum"]
 description = "Native Rust bindings for @horsicq's Detect-It-Easy"
 homepage = "https://github.com/elastic/die-rust"
@@ -21,7 +21,7 @@ name = "scan_file"
 
 [dependencies]
 bitflags = "2.6.0"
-derive_more = { version = "1.0.0", features = ["from", "display"] }
+derive_more = { version = "2.0.1", features = ["from", "display"] }
 
 [dev-dependencies]
 clap = { version = "4.5.23", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -40,31 +40,31 @@ The build requires Qt6 libraries. On Linux/macOS they can usually be obtained fr
 ### Linux
 
 ```bash
-export QT_BUILD_VERSION=6.2.2
+export QT_BUILD_VERSION=6.10.0
 git clone https://github.com/elastic/die-rust.git && cd die-rust
 python -m pip install aqtinstall
 python -m aqt install-qt -O ./libdie++/build/ linux desktop ${QT_BUILD_VERSION} gcc_64
-export QT6_LIB_PATH=./libdie++/build/6.2.2/gcc_64/lib
+export QT6_LIB_PATH=./libdie++/build/6.10.0/gcc_64/lib
 ```
 
 ### macOS
 
 ```bash
-export QT_BUILD_VERSION=6.2.2
+export QT_BUILD_VERSION=6.10.0
 git clone https://github.com/calladoum-elastic/die-rust.git && cd die-rust
 python -m pip install aqtinstall
 python -m aqt install-qt -O ./libdie++/build/ mac desktop ${QT_BUILD_VERSION} clang_64
-export QT6_LIB_PATH=./libdie++/build/6.2.2/clang_64/lib # macos
+export QT6_LIB_PATH=./libdie++/build/6.10.0/clang_64/lib # macos
 ```
 
 ### Windows
 
 ```pwsh
-$env:QT_BUILD_VERSION="6.2.2"
+$env:QT_BUILD_VERSION="6.10.0"
 git clone https://github.com/calladoum-elastic/die-rust.git && cd die-rust
 python -m pip install aqtinstall
-python -m aqt install-qt -O ./libdie++/build/ windows desktop $env:QT_BUILD_VERSION win64_msvc2019_64
-$env:QT6_LIB_PATH="./libdie++/build/6.2.2/msvc2019_64/lib"
+python -m aqt install-qt -O ./libdie++/build/ windows desktop $env:QT_BUILD_VERSION win64_msvc2022_64
+$env:QT6_LIB_PATH="./libdie++/build/6.10.0/msvc2022_64/lib"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -12,20 +12,8 @@ This module provides Rust bindings for the [Detect-It-Easy](https://github.com/h
 
 ### Build
 
-> [!IMPORTANT]
-> [**Qt6**](https://qt.io) libraries must be installed for Detect-it-Easy to work.
-> On Linux and macOS, `die-rust` can be built using the Qt6 provided by the typical package management systems (`apt`, `dnf`, `brew`, etc.).
-> If you do not wish to install those packages system-wide, if you are running Windows, or if you wish/need to use a specific version of Qt6, it is possible to build `die-rust` by installing those libraries in a specific folder, using [`aqtinstall`](https://github.com/miurahr/aqtinstall) - (see below). Then build `die-rust` by passing the paths to the Qt6 libraries with the `QT6_LIB_PATH` environment.
-
-### As a dependency
-
-Use `cargo` to add `die-rust` as a dependency to your project:
-
-```console
-cargo add --git https://github.com/elastic/die-rust.git
-```
-
-### On the terminal
+> [!Warning]
+> `Detect-It-Easy` has a hard requirement for Qt6 libraries. `cargo build` will manage the entire building process in an automated, but to be able to link against Qt6, it will use the library [`aqtinstall`](). Therefore `python` must be installed on the system. Note that downloading the Qt libraries may take some time, depending on your Internet connection.
 
 The installation can be done using `cargo`.
 
@@ -34,40 +22,6 @@ git clone https://github.com/elastic/die-rust.git
 cd die-rust
 cargo build
 ```
-
-The build requires Qt6 libraries. On Linux/macOS they can usually be obtained from the system's package manager. To use a specific Qt6 version, it is possible to use `aqtinstall` as follow
-
-### Linux
-
-```bash
-export QT_BUILD_VERSION=6.10.0
-git clone https://github.com/elastic/die-rust.git && cd die-rust
-python -m pip install aqtinstall
-python -m aqt install-qt -O ./libdie++/build/ linux desktop ${QT_BUILD_VERSION} gcc_64
-export QT6_LIB_PATH=./libdie++/build/6.10.0/gcc_64/lib
-```
-
-### macOS
-
-```bash
-export QT_BUILD_VERSION=6.10.0
-git clone https://github.com/calladoum-elastic/die-rust.git && cd die-rust
-python -m pip install aqtinstall
-python -m aqt install-qt -O ./libdie++/build/ mac desktop ${QT_BUILD_VERSION} clang_64
-export QT6_LIB_PATH=./libdie++/build/6.10.0/clang_64/lib # macos
-```
-
-### Windows
-
-```pwsh
-$env:QT_BUILD_VERSION="6.10.0"
-git clone https://github.com/calladoum-elastic/die-rust.git && cd die-rust
-python -m pip install aqtinstall
-python -m aqt install-qt -O ./libdie++/build/ windows desktop $env:QT_BUILD_VERSION win64_msvc2022_64
-$env:QT6_LIB_PATH="./libdie++/build/6.10.0/msvc2022_64/lib"
-```
-
-
 
 
 

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ fn get_qt_libs_path() -> String {
     return format!("./{LIBDIE_BUILD_DIR}/{QT_VERSION}/msvc2022_64/lib");
 
     #[cfg(target_os = "macos")]
-    return format!("./{LIBDIE_BUILD_DIR}/{QT_VERSION}/clang_64/lib");
+    return format!("./{LIBDIE_BUILD_DIR}/{QT_VERSION}/macos/lib");
 
     #[cfg(target_os = "linux")]
     return format!("./{LIBDIE_BUILD_DIR}/{QT_VERSION}/gcc_64/lib");

--- a/build.rs
+++ b/build.rs
@@ -143,15 +143,15 @@ fn setup_common() {
         println!("cargo:rustc-link-search=native={}", qt_lib_path);
     }
 
-    if BUILD_TYPE == "Release" {
-        println!("cargo:rustc-link-lib=static=Qt6Core");
-        println!("cargo:rustc-link-lib=static=Qt6Qml");
-        println!("cargo:rustc-link-lib=static=Qt6Network");
+    // if BUILD_TYPE == "Release" {
+    //     println!("cargo:rustc-link-lib=static=Qt6Core");
+    //     println!("cargo:rustc-link-lib=static=Qt6Qml");
+    //     println!("cargo:rustc-link-lib=static=Qt6Network");
 
-        println!("cargo:rustc-link-lib=dylib=Qt6Core");
-        println!("cargo:rustc-link-lib=dylib=Qt6Qml");
-        println!("cargo:rustc-link-lib=dylib=Qt6Network");
-    }
+    //     println!("cargo:rustc-link-lib=dylib=Qt6Core");
+    //     println!("cargo:rustc-link-lib=dylib=Qt6Qml");
+    //     println!("cargo:rustc-link-lib=dylib=Qt6Network");
+    // }
 }
 
 #[cfg(target_os = "linux")]

--- a/build.rs
+++ b/build.rs
@@ -160,8 +160,11 @@ fn setup_common() {
 
 #[cfg(target_os = "linux")]
 fn install() {
-    println!("cargo:rustc-link-search=native={}/die", INSTALL_DIR);
-    println!("cargo:rustc-link-search=native={}/die/lib", INSTALL_DIR);
+    println!("cargo:rustc-link-search=native={}/die", LIBDIE_INSTALL_DIR);
+    println!(
+        "cargo:rustc-link-search=native={}/die/lib",
+        LIBDIE_INSTALL_DIR
+    );
     println!("cargo:rustc-link-lib=dylib=stdc++");
     println!("cargo:rustc-link-lib=dylib=Qt6Core");
     println!("cargo:rustc-link-lib=dylib=Qt6Qml");
@@ -179,8 +182,11 @@ fn install() {
 
 #[cfg(target_os = "macos")]
 fn install() {
-    println!("cargo:rustc-link-search=native={}/die", INSTALL_DIR);
-    println!("cargo:rustc-link-search=native={}/die/lib", INSTALL_DIR);
+    println!("cargo:rustc-link-search=native={}/die", LIBDIE_INSTALL_DIR);
+    println!(
+        "cargo:rustc-link-search=native={}/die/lib",
+        LIBDIE_INSTALL_DIR
+    );
     println!("cargo:rustc-link-lib=dylib=c++");
 
     if let Some(qt_lib_path) = option_env!("QT6_LIB_PATH") {
@@ -249,9 +255,20 @@ fn should_rebuild_libdie() -> bool {
     let mut fpath = std::path::PathBuf::from(LIBDIE_INSTALL_DIR);
 
     #[cfg(target_os = "windows")]
-    fpath.push("die.lib");
+    {
+        fpath.push("die.lib");
+        fpath.exists() == false
+    }
 
-    fpath.exists() == false
+    #[cfg(target_os = "linux")]
+    {
+        true
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        true
+    }
 }
 
 fn main() {

--- a/build.rs
+++ b/build.rs
@@ -257,7 +257,7 @@ fn should_rebuild_libdie() -> bool {
     fpath.push("lib/libdie.a");
 
     #[cfg(target_os = "macos")]
-    fpath.push("lib/");
+    fpath.push("lib/libdie.a");
 
     return fpath.exists() == false;
 }

--- a/libdie++/cmake/FindDieLibrary.cmake
+++ b/libdie++/cmake/FindDieLibrary.cmake
@@ -1,10 +1,10 @@
 include(FetchContent)
 
 set(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
-set(QT_BUILD_VERSION "6.2.2")
+set(QT_BUILD_VERSION "6.10.0")
 
 if(WIN32)
-  set(QT_BUILD_COMPILER "msvc2019_64")
+  set(QT_BUILD_COMPILER "msvc2022_64")
 elseif(LINUX)
   set(QT_BUILD_COMPILER "gcc_64")
 elseif(APPLE)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,7 @@ mod tests {
 
         let flags = ScanFlags::DEEP_SCAN;
         let res = scan_file(fname, flags).unwrap();
+        assert_ne!(res.len(), 0);
         #[cfg(not(target_os = "macos"))]
         assert!(
             res.starts_with(expected_type),
@@ -319,9 +320,11 @@ mod tests {
         let fname = default_test_file();
         let expected_type = default_test_file_type();
 
-        let flags = ScanFlags::DEEP_SCAN;
+        let flags = ScanFlags::DEEP_SCAN | ScanFlags::VERBOSE;
         if let Ok(db_path) = std::env::var("DIE_DB_PATH") {
             let res = scan_file_with_db(&fname, flags, Path::new(&db_path)).unwrap();
+            assert_ne!(res.len(), 0);
+            #[cfg(not(target_os = "macos"))]
             assert!(
                 res.starts_with(expected_type),
                 "unexpected result: got {:?}, expected {:?}",
@@ -343,6 +346,7 @@ mod tests {
         let mem = unsafe { Mmap::map(&file).unwrap() };
 
         let res = scan_memory(mem.as_ref(), flags).unwrap();
+        assert_ne!(res.len(), 0);
         #[cfg(not(target_os = "macos"))]
         assert!(
             res.starts_with(expected_type),
@@ -357,12 +361,14 @@ mod tests {
         let fname = default_test_file();
         let expected_type = default_test_file_type();
 
-        let flags = ScanFlags::DEEP_SCAN;
+        let flags = ScanFlags::DEEP_SCAN | ScanFlags::VERBOSE;
         let file = File::open(fname).unwrap();
         let mem = unsafe { Mmap::map(&file).unwrap() };
 
         if let Ok(db_path) = std::env::var("DIE_DB_PATH") {
             let res = scan_memory_with_db(mem.as_ref(), flags, Path::new(&db_path)).unwrap();
+            assert_ne!(res.len(), 0);
+            #[cfg(not(target_os = "macos"))]
             assert!(
                 res.starts_with(expected_type),
                 "unexpected result: got {:?}, expected {:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,6 @@ mod tests {
 
         let flags = ScanFlags::DEEP_SCAN;
         let res = scan_file(fname, flags).unwrap();
-        assert_ne!(res.len(), 0);
         #[cfg(not(target_os = "macos"))]
         assert!(
             res.starts_with(expected_type),
@@ -346,7 +345,6 @@ mod tests {
         let mem = unsafe { Mmap::map(&file).unwrap() };
 
         let res = scan_memory(mem.as_ref(), flags).unwrap();
-        assert_ne!(res.len(), 0);
         #[cfg(not(target_os = "macos"))]
         assert!(
             res.starts_with(expected_type),


### PR DESCRIPTION
Minor updates:
 - Qt6 6.2.2 -> 6.10.0
 - MSVC 2019 -> MSVC 2022
 - Only use latest images for CI
 - Fixed tests and examples to use environment variable `DIE_DB_PATH` if defined